### PR TITLE
Added missed comma in rank list

### DIFF
--- a/src/DataObject.h
+++ b/src/DataObject.h
@@ -67,7 +67,7 @@ private:
 		"Silver 3",
 		"Silver 4",
 		"Silver Elite",
-		"Silver Elite Master"
+		"Silver Elite Master",
 		"Gold Nova 1",
 		"Gold Nova 2",
 		"Gold Nova 3",


### PR DESCRIPTION
Without it the application shows incorrect rank string for Gold Nova 1 and above and may crash for any user with Global Elite rank